### PR TITLE
Rahul/ifl 1545 investigate debug command failure

### DIFF
--- a/src/commands/debug.ts
+++ b/src/commands/debug.ts
@@ -49,7 +49,6 @@ export default class Debug extends IronfishCommand {
 
     let output = this.baseOutput(node)
     if (dbOpen) {
-      // await node.connectRpc()
       output = new Map([...output, ...(await this.outputRequiringDB(node))])
     }
 


### PR DESCRIPTION
Previous issue: 

![image](https://github.com/iron-fish/ironfish-wallet-cli/assets/13268167/3a162240-34c5-48c0-a9ea-89d65745f19d)

Issue: 

Basically the command was trying to use the `chainGetBlock` command when the walletNode was not connected. We decided that the `status` takes care of the above request by showing the `Head in Chain` status. So we removed that from the `debug` output and also cleaned up the code a bit

Fixed: 

<img width="978" alt="image" src="https://github.com/iron-fish/ironfish-wallet-cli/assets/13268167/a67ab5d7-06cf-4a7a-81b7-982c52e428f9">
