### PR TITLE
requires nodeClient to connect for rescans

### DIFF
--- a/src/commands/rescan.ts
+++ b/src/commands/rescan.ts
@@ -40,7 +40,10 @@ export class RescanCommand extends IronfishCommand {
       this.error('You cannot pass both --local and --no-follow')
     }
 
-    const client = await connectRpcWallet(this.sdk, { forceLocal: local })
+    const client = await connectRpcWallet(this.sdk, {
+      forceLocal: local,
+      connectNodeClient: true,
+    })
 
     CliUx.ux.action.start('Asking node to start scanning', undefined, {
       stdout: true,


### PR DESCRIPTION
rescanning requires receiving blocks from a remote node. the wallet cannot rescan if its nodeClient is not connected

if a user runs `ironfishw rescan -f` without the wallet already running, then the wallet should still be able to rescan

manual testing with and without wallet already running