### PR TITLE
updates wallet.createAccount usage

### DIFF
--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -184,10 +184,9 @@ export default class WalletStart extends IronfishCommand {
 
   private async setDefaultAccount(node: IronfishNode): Promise<void> {
     if (!node.wallet.accountExists(DEFAULT_ACCOUNT_NAME)) {
-      const account = await node.wallet.createAccount(
-        DEFAULT_ACCOUNT_NAME,
-        true,
-      )
+      const account = await node.wallet.createAccount(DEFAULT_ACCOUNT_NAME, {
+        setDefault: true,
+      })
 
       this.log(`New default account created: ${account.name}`)
       this.log(`Account's public address: ${account.publicAddress}`)


### PR DESCRIPTION
we recently changed the parameters of createAccount in the sdk: https://github.com/iron-fish/ironfish/pull/4221

updates usage in ironfish-wallet-cli to match the new format

NOTE: do not merge until next release of "@ironfish/sdk"