### PR TITLE
Rahul/ifl 1504 add f flag to walletstatus nice to have

### DIFF
--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -86,7 +86,7 @@ export class StatusCommand extends IronfishCommand {
       // CliUX.Table does not return a string and instead prints to a custom function
 
       const logTable = (s: string) => {
-        tableBody += s
+        tableBody += s + '\n'
       }
 
       this.renderStatus(response, flags, logTable)


### PR DESCRIPTION
Changes: 

1. adding the -f follow flag
2. when the flag is on and the node is not running, let the user know that the node is stopped 
3. when the flag is on and the node is running, provide the user real time updates to the wallet status
4. when the node is turned off while the wallet status is running, let the user know that the node has been disconnected 

https://github.com/iron-fish/ironfish-wallet-cli/assets/13268167/7b3ca0d9-62fe-4ddb-8c9c-1e678e944fa5

5. when the node is stopped and the wallet status is running, then the node is turned back on, the wallet status should continue as expected (video below)


https://github.com/iron-fish/ironfish-wallet-cli/assets/13268167/ec9076d8-07de-40dc-b9ac-32b4e80b0563

