### PR TITLE
refactor(wallet-cli): Update examples to use `ironfishw`

### DIFF
--- a/.github/workflows/deploy-npm-ironfish-cli.yml
+++ b/.github/workflows/deploy-npm-ironfish-cli.yml
@@ -1,4 +1,4 @@
-name: Deploy ironfish NPM Package
+name: Deploy ironfish-wallet NPM Package
 
 env:
   DEBUG: 'napi:*'

--- a/bin/run
+++ b/bin/run
@@ -17,7 +17,7 @@ if (process.versions.node.split('.')[0] !== '18') {
     `NodeJS version ${process.versions.node} is not compatible. Must have Node v18 installed: https://nodejs.org/en/download/`,
   )
   console.log(
-    'After v18 is installed, MAKE SURE TO run `npm install -g ironfish` again to install ironfish with the correct Node version',
+    'After v18 is installed, MAKE SURE TO run `npm install -g ironfishw` again to install ironfishw with the correct Node version',
   )
   process.exit(1)
 }

--- a/src/commands/config/edit.ts
+++ b/src/commands/config/edit.ts
@@ -24,7 +24,7 @@ const readFileAsync = promisify(readFile)
 export class EditCommand extends IronfishCommand {
   static description = `Edit the config in your configured editor
 
-  Set the editor in either EDITOR environment variable, or set 'editor' in your ironfish config`
+  Set the editor in either EDITOR environment variable, or set 'editor' in your ironfishw config`
 
   static flags = {
     [ConfigFlagKey]: ConfigFlag,

--- a/src/commands/config/set.ts
+++ b/src/commands/config/set.ts
@@ -33,7 +33,7 @@ export class SetCommand extends IronfishCommand {
   }
 
   static examples = [
-    '$ ironfish config:set bootstrapNodes "test.bn1.ironfish.network,example.com"',
+    '$ ironfishw config:set walletNodeIpcPath ~/.ironfish/ironfish.ipc',
   ]
 
   async start(): Promise<void> {

--- a/src/commands/config/unset.ts
+++ b/src/commands/config/unset.ts
@@ -26,7 +26,7 @@ export class UnsetCommand extends IronfishCommand {
     }),
   }
 
-  static examples = ['$ ironfish config:unset blockGraffiti']
+  static examples = ['$ ironfishw config:unset walletNodeIpcPath']
 
   async start(): Promise<void> {
     const { args, flags } = await this.parse(UnsetCommand)

--- a/src/commands/debug.ts
+++ b/src/commands/debug.ts
@@ -65,14 +65,13 @@ export default class Debug extends IronfishCommand {
       getHeapStatistics().total_available_size,
     )
 
-    const telemetryEnabled = this.sdk.config.get('enableTelemetry').toString()
     const assetVerificationEnabled = this.sdk.config
       .get('enableAssetVerification')
       .toString()
 
     let cmdInPath: boolean
     try {
-      execSync('ironfish --help', { stdio: 'ignore' })
+      execSync('ironfishw --help', { stdio: 'ignore' })
       cmdInPath = true
     } catch {
       cmdInPath = false
@@ -87,9 +86,8 @@ export default class Debug extends IronfishCommand {
       ['RAM total', `${memTotal}`],
       ['Heap total', `${heapTotal}`],
       ['Node version', `${process.version}`],
-      ['ironfish in PATH', `${cmdInPath.toString()}`],
+      ['ironfishw in PATH', `${cmdInPath.toString()}`],
       ['Garbage Collector Exposed', `${String(!!global.gc)}`],
-      ['Telemetry enabled', `${telemetryEnabled}`],
       ['Asset Verification enabled', `${assetVerificationEnabled}`],
     ])
   }

--- a/src/utils/editor.ts
+++ b/src/utils/editor.ts
@@ -16,7 +16,7 @@ export function launchEditor(
 
   if (!editor) {
     throw new Error(
-      `you must set the EDITOR environment variable or 'editor' in the ironfish config`,
+      `you must set the EDITOR environment variable or 'editor' in the ironfishw config`,
     )
   }
 


### PR DESCRIPTION
These examples should use the executable of the standalone wallet.