### PR TITLE
Rahul/ifl 1561 bug node status command fails

### DIFF
--- a/src/commands/node/status.ts
+++ b/src/commands/node/status.ts
@@ -35,13 +35,7 @@ export default class Status extends IronfishCommand {
     const { flags } = await this.parse(Status)
 
     if (!flags.follow) {
-      const connected = await this.sdk.client.tryConnect()
-      if (!connected) {
-        this.log('Node: Disconnected')
-        this.exit(0)
-      }
-
-      const client = await connectRpcWallet(this.sdk)
+      const client = await connectRpcWallet(this.sdk, { forceRemote: true })
       const response = await client.wallet.getNodeStatus()
       this.log(renderStatus(response.content, flags.all))
       this.exit(0)


### PR DESCRIPTION
Previously we got this response when trying to connect to the get the status when the wallet is not running
<img width="801" alt="image" src="https://github.com/iron-fish/ironfish-wallet-cli/assets/13268167/bccdc042-9788-4a97-9cd2-c9ae214d0b49">

new response: 

<img width="1014" alt="image" src="https://github.com/iron-fish/ironfish-wallet-cli/assets/13268167/6098da8b-1289-4f05-ab1c-7bda26f5fe94">

