### PR TITLE
Fix reinstall message

### DIFF
--- a/bin/run
+++ b/bin/run
@@ -17,7 +17,7 @@ if (process.versions.node.split('.')[0] !== '18') {
     `NodeJS version ${process.versions.node} is not compatible. Must have Node v18 installed: https://nodejs.org/en/download/`,
   )
   console.log(
-    'After v18 is installed, MAKE SURE TO run `npm install -g ironfishw` again to install ironfishw with the correct Node version',
+    'After v18 is installed, MAKE SURE TO run `npm install -g ironfish-wallet` again to install ironfish-wallet with the correct Node version',
   )
   process.exit(1)
 }


### PR DESCRIPTION
The re-install message incorrectly tells the user to `npm install ironfishw` which is not an official npm pacakge. Changing to the correct npm package name
