### PR TITLE
Fixed RpcServer context missing items

### DIFF
--- a/src/walletNode.ts
+++ b/src/walletNode.ts
@@ -101,7 +101,7 @@ export class WalletNode {
     this.strategy = strategy
     this.metrics = metrics
     this.workerPool = workerPool
-    this.rpc = new RpcServer({ config }, internal)
+    this.rpc = new RpcServer(this, internal)
     this.logger = logger
     this.pkg = pkg
     this.nodeClient = nodeClient


### PR DESCRIPTION
### Summary
This was constructing a bare bones context. With this change, it passes the entire WalletNode into the RpcServer to fullfil most of the context items it needs.

### More Explanation
This started with an error shown in discord https://discord.com/channels/771503434028941353/828767731305676810/1200532459520008306

The error is:
```
Expected RPC context to have keys wallet but has config
Error: Expected RPC context to have keys wallet but has config
    at Assert.hasKeys (/usr/lib/node_modules/ironfish-wallet/node_modules/@ironfish/sdk/build/src/assert.js:84:19)
    at AssertHasRpcContext (/usr/lib/node_modules/ironfish-wallet/node_modules/@ironfish/sdk/build/src/rpc/routes/rpcContext.js:11:21)
    at /usr/lib/node_modules/ironfish-wallet/node_modules/@ironfish/sdk/build/src/rpc/routes/wallet/getAccountsStatus.js:46:42
    at Router.route (/usr/lib/node_modules/ironfish-wallet/node_modules/@ironfish/sdk/build/src/rpc/routes/router.js:44:19)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async RpcIpcAdapter.onClientData (/usr/lib/node_modules/ironfish-wallet/node_modules/@ironfish/sdk/build/src/rpc/adapters/socketAdapter/socketAdapter.js:184:17)
```

We check the context has `wallet` here https://github.com/iron-fish/ironfish/blob/ed059690f9961bf08a7b44d90c99c0df62be1bef/ironfish/src/rpc/routes/wallet/getAccountStatus.ts#L33 but we only passed in `config` here https://github.com/iron-fish/ironfish-wallet-cli/pull/52/files#diff-07f8a28804f8b3ef23b000fc52b96dcb9795eb981f222b0f8ff7128ef6812d6cL104.

By passing in the whole WalletNode we fullfil most of the requirements of RpcContext which is defined as
```ts
export type RpcContext = Partial<{
  config: Config
  internal: InternalStore
  files: FileSystem
  wallet: Wallet
  workerPool: WorkerPool
  logger: Logger
  rpc: RpcServer
  assetsVerifier: AssetsVerifier
  strategy: Strategy
  shutdown: () => Promise<void>
}>
```

