### PR TITLE
Fix being able to set network definition on startup

### DIFF
--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -87,10 +87,19 @@ export default class WalletStart extends IronfishCommand {
     this.loadFlagsIntoConfig(flags)
     this.validateWalletConfig()
 
+    const { networkId, customNetwork } = flags
+    if (networkId !== undefined && customNetwork !== undefined) {
+      throw new Error(
+        'Cannot specify both the networkId and customNetwork flags at the same time',
+      )
+    }
+
     const node = await walletNode({
       connectNodeClient: true,
       sdk: this.sdk,
       walletConfig: this.walletConfig,
+      customNetworkPath: customNetwork,
+      networkId,
     })
 
     this.log(`\n${ONE_FISH_IMAGE}`)
@@ -177,7 +186,7 @@ export default class WalletStart extends IronfishCommand {
   }
 
   private loadFlagsIntoConfig(flags: CommandFlags<typeof WalletStart>) {
-    const { name, workers, upgrade, networkId, customNetwork } = flags
+    const { name, workers, upgrade } = flags
     const config = this.sdk.config
 
     if (workers !== undefined && workers !== config.get('nodeWorkers')) {
@@ -190,19 +199,6 @@ export default class WalletStart extends IronfishCommand {
 
     if (upgrade !== undefined && upgrade !== config.get('databaseMigrate')) {
       config.setOverride('databaseMigrate', upgrade)
-    }
-
-    if (networkId !== undefined && customNetwork !== undefined) {
-      throw new Error(
-        'Cannot specify both the networkId and customNetwork flags at the same time',
-      )
-    }
-
-    if (
-      customNetwork !== undefined &&
-      customNetwork !== config.get('customNetwork')
-    ) {
-      config.setOverride('customNetwork', customNetwork)
     }
   }
 }

--- a/src/walletNode.ts
+++ b/src/walletNode.ts
@@ -130,6 +130,8 @@ export class WalletNode {
     metrics,
     files,
     nodeClient,
+    customNetworkPath,
+    networkId,
   }: {
     pkg: Package
     dataDir?: string
@@ -139,6 +141,8 @@ export class WalletNode {
     metrics?: MetricsMonitor
     files: FileSystem
     nodeClient: RpcSocketClient | null
+    customNetworkPath?: string
+    networkId?: number
   }): Promise<WalletNode> {
     logger = logger.withTag('walletnode')
     dataDir = dataDir || DEFAULT_DATA_DIR
@@ -176,6 +180,8 @@ export class WalletNode {
       config,
       internal,
       files,
+      customNetworkPath,
+      networkId,
     )
 
     const network = new Network(networkDefinition)
@@ -428,6 +434,8 @@ export async function walletNode(options: {
   sdk: IronfishSdk
   connectNodeClient: boolean
   walletConfig: WalletConfig
+  customNetworkPath?: string
+  networkId?: number
 }): Promise<WalletNode> {
   let nodeClient: RpcSocketClient | null = null
 
@@ -467,6 +475,8 @@ Use 'ironfish config:set' to connect to a node via TCP, TLS, or IPC.\n`)
     logger: options.sdk.logger,
     metrics: options.sdk.metrics,
     dataDir: options.sdk.dataDir,
+    customNetworkPath: options.customNetworkPath,
+    networkId: options.networkId,
     nodeClient,
   })
 


### PR DESCRIPTION
When the SDK was updated the most recent time setting the networkId changed. Fixing to correctly be able to set the network on startup
