### PR TITLE
fix rendering of head info in standalone wallet status

### DIFF
--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -104,12 +104,15 @@ export class StatusCommand extends IronfishCommand {
           header: 'Account ID',
         },
         headHash: {
+          get: (row) => row.head?.hash ?? 'NULL',
           header: 'Head Hash',
         },
         headInChain: {
+          get: (row) => row.head?.inChain ?? 'NULL',
           header: 'Head In Chain',
         },
         sequence: {
+          get: (row) => row.head?.sequence ?? 'NULL',
           header: 'Head Sequence',
         },
       },


### PR DESCRIPTION
we need to define how to access fields from each row because the fields are nested within the 'head' object for each account

manual testing:
<img width="1009" alt="image" src="https://github.com/iron-fish/ironfish-wallet-cli/assets/57735705/a1f4e69b-67cd-4ba9-9ee7-46ba3a85ccdb">
