### PR TITLE
adds missing ': ' to longPrompt

### DIFF
--- a/src/utils/longPrompt.ts
+++ b/src/utils/longPrompt.ts
@@ -19,7 +19,7 @@ export async function longPrompt(
     })
 
   const userInput = await new Promise<string>((resolve) => {
-    rl.question(question, (answer) => {
+    rl.question(question + ': ', (answer) => {
       resolve(answer.trim())
     })
   })


### PR DESCRIPTION
matches ironfish repo and makes it easier to distinguish between the prompt and user entry

also matches oclif prompts